### PR TITLE
Get certs mock working with salt 2019.2

### DIFF
--- a/lib/kitchen/provisioner/_states/mock.py
+++ b/lib/kitchen/provisioner/_states/mock.py
@@ -65,11 +65,7 @@ def remote_functions(name):
 def _mock_publish(tgt, fun, arg=None, tgt_type='glob', returner='', timeout=5, via_master=None, expr_form=None):
     global remote_functions_data
     log.info('MOCK: Publishing {0!r} for {1}'.format(fun, tgt))
-    log.debug('MOCK: arg type: {0}'.format(type(arg)))
-    log.debug('MOCK: arg: {0!r}'.format(arg))
     kwargs = salt.utils.args.yamlify_arg(arg)
-    log.debug('MOCK: kwargs type: {0}'.format(type(kwargs)))
-    log.debug('MOCK: kwargs: {0}'.format(kwargs))
 
     # Special case some functions for convinient usage
     # TODO(ppg): allow custom python files provided to override a function

--- a/lib/kitchen/provisioner/_states/mock.py
+++ b/lib/kitchen/provisioner/_states/mock.py
@@ -14,13 +14,29 @@ log = logging.getLogger(__name__)
 mine_data = {}
 remote_functions_data = {}
 
+
 def mine(name):
     global mine_data
     # FIXME(ppg): drive via configuration
     for file in glob.glob('/tmp/kitchen/srv/mine/*'):
         mine_data.update(yaml.load(open(file)))
     __salt__['mine.get'] = _mock_get
-    return { 'name': 'mine', 'changes': {}, 'result': True, 'comment': 'Replaced mine.get with mock' }
+    return {'name': 'mine', 'changes': {}, 'result': True, 'comment': 'Replaced mine.get with mock'}
+
+
+def _parse_args(arg):
+    '''
+    yamlify `arg` and ensure it's outermost datatype is a list
+    '''
+    yaml_args = salt.utils.args.yamlify_arg(arg)
+
+    if yaml_args is None:
+        return []
+    elif not isinstance(yaml_args, list):
+        return [yaml_args]
+    else:
+        return yaml_args
+
 
 def _mock_get(tgt, fun, tgt_type='glob', exclude_minion=False, expr_form=None):
     global mine_data
@@ -34,7 +50,8 @@ def _mock_get(tgt, fun, tgt_type='glob', exclude_minion=False, expr_form=None):
         return {}
     # TODO(ppg): allow lookup based on arg too
     d = d[fun]
-    return { tgt: d }
+    return {tgt: d}
+
 
 def remote_functions(name):
     global remote_functions_data
@@ -42,12 +59,17 @@ def remote_functions(name):
     for file in glob.glob('/tmp/kitchen/srv/remote_functions/*'):
         remote_functions_data.update(yaml.load(open(file)))
     __salt__['publish.publish'] = _mock_publish
-    return { 'name': 'remote_functions', 'changes': {}, 'result': True, 'comment': 'Replaced publish.publish with mock' }
+    return {'name': 'remote_functions', 'changes': {}, 'result': True, 'comment': 'Replaced publish.publish with mock'}
+
 
 def _mock_publish(tgt, fun, arg=None, tgt_type='glob', returner='', timeout=5, via_master=None, expr_form=None):
     global remote_functions_data
     log.info('MOCK: Publishing {0!r} for {1}'.format(fun, tgt))
+    log.debug('MOCK: arg type: {0}'.format(type(arg)))
+    log.debug('MOCK: arg: {0!r}'.format(arg))
     kwargs = salt.utils.args.yamlify_arg(arg)
+    log.debug('MOCK: kwargs type: {0}'.format(type(kwargs)))
+    log.debug('MOCK: kwargs: {0}'.format(kwargs))
 
     # Special case some functions for convinient usage
     # TODO(ppg): allow custom python files provided to override a function
@@ -55,19 +77,23 @@ def _mock_publish(tgt, fun, arg=None, tgt_type='glob', returner='', timeout=5, v
     #     'x509.sign_remote_certificate': mock_sign_remote_certificate.py
     if fun == 'x509.sign_remote_certificate':
         kwargs['text'] = True
-        return { tgt: mock_sign_remote_certificate(**kwargs) }
+        return {tgt: mock_sign_remote_certificate(**kwargs)}
 
     if tgt not in remote_functions_data:
-        raise SaltInvocationError(message='Cannot find target {} in remote functions.'.format(tgt))
+        raise SaltInvocationError(
+            message='Cannot find target {} in remote functions.'.format(tgt))
     d = remote_functions_data[tgt]
     if fun not in d:
-        raise SaltInvocationError(message='Cannot find target {} with function {} in remote functions.'.format(tgt, fun))
+        raise SaltInvocationError(
+            message='Cannot find target {} with function {} in remote functions.'.format(tgt, fun))
     d = d[fun]
     if 'ret' not in d:
-        raise SaltInvocationError(message="target {} function {} is missing 'ret' field".format(tgt, fun))
+        raise SaltInvocationError(
+            message="target {} function {} is missing 'ret' field".format(tgt, fun))
     # TODO(ppg): allow lookup based on arg too
     d = d['ret']
-    return { tgt: d }
+    return {tgt: d}
+
 
 def mock_sign_remote_certificate(**kwargs):
     return __salt__['x509.create_certificate'](**kwargs)

--- a/lib/kitchen/provisioner/_states/mock.py
+++ b/lib/kitchen/provisioner/_states/mock.py
@@ -76,6 +76,9 @@ def _mock_publish(tgt, fun, arg=None, tgt_type='glob', returner='', timeout=5, v
     #   mock_remote_functions:
     #     'x509.sign_remote_certificate': mock_sign_remote_certificate.py
     if fun == 'x509.sign_remote_certificate':
+        # if salt.utils.args.yamlify failed to make a dict, try ast
+        if not isinstance(kwargs, dict):
+            kwargs = ast.literal_eval(kwargs)
         kwargs['text'] = True
         return {tgt: mock_sign_remote_certificate(**kwargs)}
 


### PR DESCRIPTION
Use ast.literal_eval to get certs mocking to work under `2019.2.0`. Unfortunately `2018.3` is a lost cause.